### PR TITLE
Extend the context timeout to 10 Minutes from Seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func listObjectsAndDeleteOlderObjects(bucket string, prefix string, reqDays int,
 		return fmt.Errorf("storage.NewClient: %v", err)
 	}
 	defer client.Close()
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
 	defer cancel()
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix: prefix,


### PR DESCRIPTION
Increasing the context timeout from 10 Seconds to 10 Minutes as we face the below error while trying to cleanup older logs from GCS:
```
2021/02/19 07:08:32 listObjectsAndDeleteOlderObjects: Object("logs/periodic-kubernetes-conformance-test-ppc64le/1359356217046077440/podinfo.json").Delete: context deadline exceeded
exit status 1
```